### PR TITLE
fix(captcha): detect right edge and estimate left edge position

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "indent": ["error", 2],
     "padded-blocks": ["warn", { "classes": "always", "switches": "never", "blocks": "never" }],
     "linebreak-style": "off",
-    "arrow-parens": ["warn", "as-needed"]
+    "arrow-parens": ["warn", "as-needed"],
+    "operator-linebreak": ["error", "before"]
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,8 +26,9 @@ const windscribe = new WindscribeClient(config.windscribeUsername, config.windsc
 const client = new QBittorrentClient(config.clientUrl, config.clientUsername, config.clientPassword);
 
 // init schedule if configured
-const scheduledTask = !config.cronSchedule ? null :
-  schedule(config.cronSchedule, () => run('schedule'), {scheduled: false});
+const scheduledTask = !config.cronSchedule
+  ? null
+  : schedule(config.cronSchedule, () => run('schedule'), {scheduled: false});
 
 async function update() {
   let nextRetry: Date = null;


### PR DESCRIPTION
When only one edge cluster is detected in the CAPTCHA background, the algorithm now determines whether it's the left or right edge based on its position. If the cluster is in the right portion of the search area, it's treated as the right edge, and the left edge is estimated by subtracting the piece width.

Also adds operator-linebreak eslint rule to enforce operators at the beginning of lines.