### PR TITLE
fix(config): improve error message for invalid numeric env variables

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -131,7 +131,7 @@ export function getConfig(): Config {
     if (entry.type == Number) {
       const intValue = parseInt(value);
       if (isNaN(intValue)) {
-        throw new Error(`Environment variable ${entry.envVariableName}`);
+        throw new Error(`Environment variable ${entry.envVariableName} must be a valid number`);
       }
       return [name, intValue];
     }


### PR DESCRIPTION
The error thrown when a numeric env variable cannot be parsed was
missing context, making it hard to diagnose. Added 'must be a valid
number' to clarify the issue.

https://claude.ai/code/session_01JfK6DTSMP1WANhtf2BRxcM